### PR TITLE
feat: add live listening presence and runtime assistant freshness

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "predev": "node scripts/generate-ai-context.mjs",
     "dev": "astro dev",
+    "prestart": "node scripts/generate-ai-context.mjs",
     "start": "astro dev",
     "generate:ai-context": "node scripts/generate-ai-context.mjs",
     "build": "node scripts/generate-ai-context.mjs && astro build",

--- a/scripts/generate-ai-context.mjs
+++ b/scripts/generate-ai-context.mjs
@@ -61,69 +61,19 @@ function parseMdxFile(raw) {
   return { frontmatter, body };
 }
 
-async function getGithubRepos() {
-  const username = process.env.GITHUB_USERNAME;
-  if (!username) {
-    console.warn("[ai-context] Missing GITHUB_USERNAME. Skipping GitHub projects.");
-    return [];
-  }
-
-  const headers = {
-    Accept: "application/vnd.github+json",
-  };
-
-  if (process.env.GITHUB_ACCESS_TOKEN) {
-    headers.Authorization = `Bearer ${process.env.GITHUB_ACCESS_TOKEN}`;
-  }
-
-  try {
-    const response = await fetch(
-      `https://api.github.com/users/${username}/repos?sort=updated&per_page=100`,
-      { headers },
-    );
-
-    if (!response.ok) {
-      console.warn(`[ai-context] GitHub API request failed: ${response.status}`);
-      return [];
-    }
-
-    const repos = await response.json();
-    return repos
-      .filter((repo) => !repo.fork)
-      .slice(0, 40)
-      .map((repo) => ({
-        name: repo.name,
-        description: repo.description || "",
-        language: repo.language || "",
-        html_url: repo.html_url,
-        homepage: repo.homepage || "",
-        topics: Array.isArray(repo.topics) ? repo.topics : [],
-      }));
-  } catch (error) {
-    console.warn("[ai-context] Failed to fetch GitHub repositories:", error.message);
-    return [];
-  }
-}
-
 async function loadLocalData() {
   const portfolioPath = pathToFileURL(path.join(rootDir, "src/data/portfolio.js")).href;
   const musicPath = pathToFileURL(path.join(rootDir, "src/data/music.js")).href;
   const blogsPath = pathToFileURL(path.join(rootDir, "src/utils/blogs.js")).href;
-  const githubPath = pathToFileURL(path.join(rootDir, "src/utils/github.js")).href;
-  const lastfmPath = pathToFileURL(path.join(rootDir, "src/utils/lastfm.js")).href;
 
   const portfolioModule = await import(portfolioPath);
   const musicModule = await import(musicPath);
   const blogsModule = await import(blogsPath);
-  const githubModule = await import(githubPath);
-  const lastfmModule = await import(lastfmPath);
 
   return {
     portfolio: portfolioModule,
     music: musicModule,
     blogs: blogsModule.default || [],
-    github: githubModule,
-    lastfm: lastfmModule,
   };
 }
 
@@ -162,52 +112,7 @@ async function getBlogMdxChunks() {
 }
 
 async function buildContext() {
-  const { portfolio, music, blogs, github, lastfm } = await loadLocalData();
-  const githubData = await github.fetchPinnedGithubData({
-    githubUsername: process.env.GITHUB_USERNAME,
-    githubAccessToken: process.env.GITHUB_ACCESS_TOKEN,
-  });
-  const lastfmData = await lastfm.fetchLastfmData({
-    apiKey: process.env.LASTFM_API_KEY,
-    username: process.env.LASTFM_USERNAME || music.musicProfile.lastfmUsername,
-  });
-
-  if (githubData.error) {
-    console.warn(`[ai-context] ${githubData.error}`);
-  }
-
-  if (lastfmData.error && lastfmData.error !== "Missing Last.fm credentials") {
-    console.warn(`[ai-context] ${lastfmData.error}`);
-  }
-
-  const pinnedProjects = githubData.projects || [];
-  const languageStats = github.computeLanguageStats(pinnedProjects);
-  const githubRepos = pinnedProjects.map((repo) => ({
-    name: repo.name,
-    description: repo.description || "",
-    html_url: repo.url || "",
-    homepage: repo.homepageUrl || "",
-    topics: (repo.repositoryTopics?.edges || [])
-      .map((edge) => edge?.node?.topic?.name)
-      .filter(Boolean),
-    languages: (repo.languages?.edges || [])
-      .map((edge) => edge?.node?.name)
-      .filter(Boolean),
-  }));
-
-  if (githubRepos.length === 0) {
-    const fallbackRepos = await getGithubRepos();
-    for (const repo of fallbackRepos) {
-      githubRepos.push({
-        name: repo.name,
-        description: repo.description || "",
-        html_url: repo.html_url || "",
-        homepage: repo.homepage || "",
-        topics: repo.topics || [],
-        languages: repo.language ? [repo.language] : [],
-      });
-    }
-  }
+  const { portfolio, music, blogs } = await loadLocalData();
 
   const blogMdxChunks = await getBlogMdxChunks();
 
@@ -241,7 +146,7 @@ async function buildContext() {
       type: "music",
       title: "Monthly top artists before Spotify cancellation",
       content: `Manual music context: ${music.musicProfile.monthlySpotifyArtists.join(", ")}.`,
-      url: "/#music",
+      url: music.musicProfile.lastfmUrl,
       section: "music",
     }),
   );
@@ -278,95 +183,6 @@ async function buildContext() {
   });
 
   chunks.push(...blogMdxChunks);
-
-  githubRepos
-    .filter((repo) => repo.name !== "portfolio")
-    .forEach((repo) => {
-      const content = [
-        repo.description,
-        repo.languages.length ? `Languages: ${repo.languages.join(", ")}.` : "",
-        repo.topics.length ? `Topics: ${repo.topics.join(", ")}.` : "",
-        repo.homepage ? `Homepage: ${repo.homepage}.` : "",
-      ]
-        .filter(Boolean)
-        .join(" ");
-
-      chunks.push(
-        createChunk({
-          id: `project:${repo.name}`,
-          type: "project",
-          title: repo.name,
-          content,
-          url: repo.html_url,
-          section: "projects",
-        }),
-      );
-    });
-
-  if (languageStats.length) {
-    const languageSummary = languageStats
-      .map(
-        (entry) =>
-          `${entry.language}: ${entry.percent}% (${entry.projectCount}/${entry.totalProjects} pinned projects).`,
-      )
-      .join(" ");
-
-    chunks.push(
-      createChunk({
-        id: "projects:language-stats",
-        type: "project",
-        title: "Pinned project language percentages",
-        content: `Language distribution across pinned projects. ${languageSummary}`,
-        url: "/#projects",
-        section: "projects",
-      }),
-    );
-  }
-
-  if (lastfmData.recentTracks.length) {
-    chunks.push(
-      createChunk({
-        id: "music:recent-tracks",
-        type: "music",
-        title: "Recent Last.fm tracks",
-        content: lastfmData.recentTracks
-          .map((track) => `${track.name} by ${track.artist}${track.album ? ` from ${track.album}` : ""}.`)
-          .join(" "),
-        url: lastfmData.profileUrl || "/#music",
-        section: "music",
-      }),
-    );
-  }
-
-  if (lastfmData.topArtists.length) {
-    chunks.push(
-      createChunk({
-        id: "music:top-artists",
-        type: "music",
-        title: "Top artists this month",
-        content: lastfmData.topArtists
-          .map((artist) => `${artist.name}${artist.playcount ? ` (${artist.playcount} plays)` : ""}.`)
-          .join(" "),
-        url: lastfmData.profileUrl || "/#music",
-        section: "music",
-      }),
-    );
-  }
-
-  if (lastfmData.topAlbums.length) {
-    chunks.push(
-      createChunk({
-        id: "music:top-albums",
-        type: "music",
-        title: "Top albums this month",
-        content: lastfmData.topAlbums
-          .map((album) => `${album.name} by ${album.artist}${album.playcount ? ` (${album.playcount} plays)` : ""}.`)
-          .join(" "),
-        url: lastfmData.profileUrl || "/#music",
-        section: "music",
-      }),
-    );
-  }
 
   chunks.push(
     createChunk({

--- a/scripts/generate-ai-context.mjs
+++ b/scripts/generate-ai-context.mjs
@@ -107,17 +107,23 @@ async function getGithubRepos() {
 
 async function loadLocalData() {
   const portfolioPath = pathToFileURL(path.join(rootDir, "src/data/portfolio.js")).href;
+  const musicPath = pathToFileURL(path.join(rootDir, "src/data/music.js")).href;
   const blogsPath = pathToFileURL(path.join(rootDir, "src/utils/blogs.js")).href;
   const githubPath = pathToFileURL(path.join(rootDir, "src/utils/github.js")).href;
+  const lastfmPath = pathToFileURL(path.join(rootDir, "src/utils/lastfm.js")).href;
 
   const portfolioModule = await import(portfolioPath);
+  const musicModule = await import(musicPath);
   const blogsModule = await import(blogsPath);
   const githubModule = await import(githubPath);
+  const lastfmModule = await import(lastfmPath);
 
   return {
     portfolio: portfolioModule,
+    music: musicModule,
     blogs: blogsModule.default || [],
     github: githubModule,
+    lastfm: lastfmModule,
   };
 }
 
@@ -156,14 +162,22 @@ async function getBlogMdxChunks() {
 }
 
 async function buildContext() {
-  const { portfolio, blogs, github } = await loadLocalData();
+  const { portfolio, music, blogs, github, lastfm } = await loadLocalData();
   const githubData = await github.fetchPinnedGithubData({
     githubUsername: process.env.GITHUB_USERNAME,
     githubAccessToken: process.env.GITHUB_ACCESS_TOKEN,
   });
+  const lastfmData = await lastfm.fetchLastfmData({
+    apiKey: process.env.LASTFM_API_KEY,
+    username: process.env.LASTFM_USERNAME || music.musicProfile.lastfmUsername,
+  });
 
   if (githubData.error) {
     console.warn(`[ai-context] ${githubData.error}`);
+  }
+
+  if (lastfmData.error && lastfmData.error !== "Missing Last.fm credentials") {
+    console.warn(`[ai-context] ${lastfmData.error}`);
   }
 
   const pinnedProjects = githubData.projects || [];
@@ -207,6 +221,28 @@ async function buildContext() {
       content: `${portfolio.landingBody} ${portfolio.landingLinks.map((link) => link.text).join(" ")}`,
       url: "/",
       section: "home",
+    }),
+  );
+
+  chunks.push(
+    createChunk({
+      id: "music:profile",
+      type: "music",
+      title: "Music profile",
+      content: `${music.musicProfile.summary} ${music.musicProfile.aiContextNotes.join(" ")}`,
+      url: music.musicProfile.lastfmUrl,
+      section: "music",
+    }),
+  );
+
+  chunks.push(
+    createChunk({
+      id: "music:manual-top-artists",
+      type: "music",
+      title: "Monthly top artists before Spotify cancellation",
+      content: `Manual music context: ${music.musicProfile.monthlySpotifyArtists.join(", ")}.`,
+      url: "/#music",
+      section: "music",
     }),
   );
 
@@ -283,6 +319,51 @@ async function buildContext() {
         content: `Language distribution across pinned projects. ${languageSummary}`,
         url: "/#projects",
         section: "projects",
+      }),
+    );
+  }
+
+  if (lastfmData.recentTracks.length) {
+    chunks.push(
+      createChunk({
+        id: "music:recent-tracks",
+        type: "music",
+        title: "Recent Last.fm tracks",
+        content: lastfmData.recentTracks
+          .map((track) => `${track.name} by ${track.artist}${track.album ? ` from ${track.album}` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || "/#music",
+        section: "music",
+      }),
+    );
+  }
+
+  if (lastfmData.topArtists.length) {
+    chunks.push(
+      createChunk({
+        id: "music:top-artists",
+        type: "music",
+        title: "Top artists this month",
+        content: lastfmData.topArtists
+          .map((artist) => `${artist.name}${artist.playcount ? ` (${artist.playcount} plays)` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || "/#music",
+        section: "music",
+      }),
+    );
+  }
+
+  if (lastfmData.topAlbums.length) {
+    chunks.push(
+      createChunk({
+        id: "music:top-albums",
+        type: "music",
+        title: "Top albums this month",
+        content: lastfmData.topAlbums
+          .map((album) => `${album.name} by ${album.artist}${album.playcount ? ` (${album.playcount} plays)` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || "/#music",
+        section: "music",
       }),
     );
   }

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -38,7 +38,7 @@ const {
     }
     {
       isContributor && (
-        <span class="dark:text-green-400 text-green-700 p-1 h-6 flex items-center rounded-full border dark:border-green-400 border-green-700 text-xs">
+        <span class="dark:text-sky-300 text-sky-700 p-1 h-6 flex items-center rounded-full border dark:border-sky-300 border-sky-700 text-xs">
           contributor
         </span>
       )

--- a/src/components/Landing.astro
+++ b/src/components/Landing.astro
@@ -56,8 +56,8 @@ const { title, body, links, imageUrl } = Astro.props;
                   target="_blank"
                   class={`font-bold ${
                     i === 0
-                      ? "dark:text-[#FF722F] text-[#9E3100]"
-                      : "dark:text-neutral-300 text-black"
+                      ? "text-[var(--color-brand-strong)]"
+                      : "text-[var(--color-text-strong)] dark:text-[var(--color-text)]"
                   }  hover:underline`}
                 >
                   {link.text}

--- a/src/components/react/Cal.tsx
+++ b/src/components/react/Cal.tsx
@@ -8,7 +8,6 @@ export default function CalEmbed() {
   useEffect(() => {
     (async function () {
       const Cal = await getCalApi();
-
       const theme =
         localStorage.getItem("theme") === "light" ? "light" : "dark";
 

--- a/src/components/react/Nav.tsx
+++ b/src/components/react/Nav.tsx
@@ -51,6 +51,7 @@ export default function Nav({
   const [nowPlaying, setNowPlaying] = useState<NowPlayingTrack | null>(null);
   const [isMusicOpen, setIsMusicOpen] = useState(false);
   const mobileMusicRef = useRef<HTMLDivElement | null>(null);
+  const isHome = currentPath === "/";
 
   useEffect(() => {
     function updatePosition() {
@@ -86,11 +87,9 @@ export default function Nav({
     }
 
     void loadNowPlaying();
-    const intervalId = window.setInterval(loadNowPlaying, 60_000);
 
     return () => {
       isMounted = false;
-      window.clearInterval(intervalId);
     };
   }, []);
 
@@ -118,7 +117,6 @@ export default function Nav({
     };
   }, []);
 
-  const isHome = currentPath === "/";
   const safeTrackName = nowPlaying ? censorExplicitText(nowPlaying.name) : "";
   const safeArtistName = nowPlaying ? censorExplicitText(nowPlaying.artist) : "";
 

--- a/src/components/react/Nav.tsx
+++ b/src/components/react/Nav.tsx
@@ -1,5 +1,33 @@
 import { theme as themeStore } from "../../store";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+interface NowPlayingTrack {
+  name: string;
+  artist: string;
+  album: string;
+  url: string;
+}
+
+const EXPLICIT_PATTERNS: RegExp[] = [
+  /\bexplicit\b/gi,
+  /\bshit\b/gi,
+  /\bfuck(?:ing)?\b/gi,
+  /\bbitch(?:es)?\b/gi,
+  /\bass\b/gi,
+  /\bdamn\b/gi,
+  /\bhell\b/gi,
+  /\bnigga(?:s)?\b/gi,
+  /\bhoe(?:s)?\b/gi,
+];
+
+function censorExplicitText(value: string) {
+  return EXPLICIT_PATTERNS.reduce((cleaned, pattern) => {
+    return cleaned.replace(pattern, (match) => {
+      if (match.length <= 2) return "*".repeat(match.length);
+      return `${match[0]}${"*".repeat(match.length - 2)}${match[match.length - 1]}`;
+    });
+  }, value).replace(/\s+/g, " ").trim();
+}
 
 export default function Nav({
   currentPath,
@@ -20,6 +48,9 @@ export default function Nav({
   };
 
   const [scrollPosition, setPosition] = useState<number>(0);
+  const [nowPlaying, setNowPlaying] = useState<NowPlayingTrack | null>(null);
+  const [isMusicOpen, setIsMusicOpen] = useState(false);
+  const mobileMusicRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     function updatePosition() {
@@ -32,7 +63,64 @@ export default function Nav({
     return () => window.removeEventListener("scroll", updatePosition);
   }, []);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadNowPlaying() {
+      try {
+        const response = await fetch("/api/now-playing");
+        if (!response.ok) return;
+
+        const json = await response.json();
+        if (!isMounted) return;
+        setNowPlaying(json?.track || null);
+        if (!json?.track) {
+          setIsMusicOpen(false);
+        }
+      } catch {
+        if (isMounted) {
+          setNowPlaying(null);
+          setIsMusicOpen(false);
+        }
+      }
+    }
+
+    void loadNowPlaying();
+    const intervalId = window.setInterval(loadNowPlaying, 60_000);
+
+    return () => {
+      isMounted = false;
+      window.clearInterval(intervalId);
+    };
+  }, []);
+
+  useEffect(() => {
+    function handlePointerDown(event: MouseEvent | TouchEvent) {
+      if (!mobileMusicRef.current) return;
+      if (mobileMusicRef.current.contains(event.target as Node)) return;
+      setIsMusicOpen(false);
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsMusicOpen(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("touchstart", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("touchstart", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
   const isHome = currentPath === "/";
+  const safeTrackName = nowPlaying ? censorExplicitText(nowPlaying.name) : "";
+  const safeArtistName = nowPlaying ? censorExplicitText(nowPlaying.artist) : "";
 
   return (
     <nav
@@ -40,13 +128,76 @@ export default function Nav({
       id="nav"
     >
       <div className="flex items-center justify-between mx-auto">
-        <div className="flex justify-center gap-4 items-center w-full h-14 mx-auto sm:text-left text-center">
+        <div className="flex justify-center gap-4 items-center w-full min-h-14 py-2 mx-auto sm:text-left text-center">
           <a
             href="/"
             className="rounded-lg font-semibold hover:dark:text-neutral-300 hover:text-neutral-700 dark:text-neutral-50 sm:text-base text-sm"
           >
             Boston Rohan
           </a>
+
+          {isHome && nowPlaying && (
+            <>
+              <a
+                href={nowPlaying.url}
+                target="_blank"
+                rel="noreferrer"
+                className="music-now-playing hidden md:flex items-center gap-2 ml-3 px-2.5 py-1 text-xs text-left transition"
+                aria-label={`Currently listening to ${safeTrackName} by ${safeArtistName}`}
+              >
+                <span className="music-note-cloud" aria-hidden="true">
+                  <span className="music-note-track">
+                    <span className="music-note music-note-one">♪</span>
+                    <span className="music-note music-note-two">♫</span>
+                    <span className="music-note music-note-three">♪</span>
+                  </span>
+                </span>
+                <span className="music-now-playing-copy">
+                  <span className="music-now-playing-label">Listening</span>
+                  <span className="truncate max-w-[12rem]">
+                    {safeTrackName} - {safeArtistName}
+                  </span>
+                </span>
+              </a>
+              <div className="relative flex md:hidden ml-2" ref={mobileMusicRef}>
+                <button
+                  type="button"
+                  className="music-now-playing music-now-playing-mobile flex items-center justify-center transition"
+                  aria-label={`Currently listening to ${safeTrackName} by ${safeArtistName}`}
+                  aria-expanded={isMusicOpen}
+                  aria-haspopup="dialog"
+                  onClick={() => setIsMusicOpen((current) => !current)}
+                >
+                  <span className="music-note-cloud music-note-cloud-mobile" aria-hidden="true">
+                    <span className="music-note-track">
+                      <span className="music-note music-note-one">♪</span>
+                      <span className="music-note music-note-two">♫</span>
+                      <span className="music-note music-note-three">♪</span>
+                    </span>
+                  </span>
+                </button>
+                {isMusicOpen && (
+                  <div
+                    className="music-popover music-popover-mobile absolute left-1/2 top-[calc(100%+0.5rem)] w-52 max-w-[calc(100vw-1rem)] rounded-2xl px-3 py-2 text-left"
+                    role="dialog"
+                    aria-label="Current song"
+                  >
+                    <p className="music-popover-label">Listening now</p>
+                    <p className="music-popover-title">{safeTrackName}</p>
+                    <p className="music-popover-meta">{safeArtistName}</p>
+                    <a
+                      href={nowPlaying.url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="music-popover-link"
+                    >
+                      Open track
+                    </a>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
 
           <div className="ml-auto flex flex-row-reverse items-center">
             <button

--- a/src/components/react/PortfolioAssistant.tsx
+++ b/src/components/react/PortfolioAssistant.tsx
@@ -97,7 +97,7 @@ export default function PortfolioAssistant({ imageUrl }: { imageUrl?: string }) 
         },
         body: JSON.stringify({
           message,
-          history: nextHistory.map((entry) => ({
+          history: messages.map((entry) => ({
             role: entry.role,
             content: entry.content,
           })),

--- a/src/data/music.js
+++ b/src/data/music.js
@@ -1,0 +1,11 @@
+export const musicProfile = {
+  lastfmUsername: "bostonrohan",
+  lastfmUrl: "https://www.last.fm/user/bostonrohan",
+  summary:
+    "Music is part of Boston Rohan's day-to-day routine. Last.fm captures YouTube Music listening on desktop, while manual notes fill in broader taste that may not appear in scrobbles.",
+  monthlySpotifyArtists: ["Drake", "Don Toliver", "Jordan Ward", "J. Cole"],
+  aiContextNotes: [
+    "Spotify monthly top artists before canceling Spotify included Drake, Don Toliver, Jordan Ward, and J. Cole.",
+    "Last.fm data may undercount listening because YouTube Music app sessions do not reliably scrobble.",
+  ],
+};

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -5,7 +5,7 @@ export const landingLinks = [
   { text: "code,", url: "https://github.com/BostonRohan" },
   {
     text: "listen to music,",
-    url: "https://open.spotify.com/user/12151292580?si=908c62d3ccc04bf3",
+    url: "https://www.last.fm/user/bostonrohan",
   },
   { text: "watch anime.", url: "https://anilist.co/user/bosston/" },
 ];
@@ -70,13 +70,13 @@ export const contactSummary =
   "Schedule a call or connect via LinkedIn and GitHub.";
 
 export const assistantIntro =
-  "Self taught developer currently working at Elevation Church. code, listen to music, and watch anime.";
+  "Self taught developer currently working at Elevation Church. code, listen to music, and watch anime. Ask about projects, work, blog posts, or what is in the current music rotation.";
 
 export const suggestedPrompts = [
   "what language dominates your pinned projects",
+  "what have you been listening to lately",
+  "who are your top artists this month",
   "what projects have you built",
   "what technologies do you use",
-  "what are you working on now",
   "show me your blog",
-  "how can I contact you",
 ];

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -4,7 +4,7 @@ import bundledContext from "../../../generated/ai-context.json";
 
 interface ContextChunk {
   id: string;
-  type: "bio" | "project" | "experience" | "blog" | "contact";
+  type: "bio" | "project" | "experience" | "blog" | "contact" | "music";
   title?: string;
   content: string;
   url?: string;
@@ -32,7 +32,7 @@ const ACTION_TARGETS: Record<Exclude<ChatAction, "none">, string[]> = {
   highlight: ["projects", "experience", "blog", "contact"],
 };
 
-const DEFAULT_SUGGESTIONS = ["projects", "experience", "blog", "contact"];
+const DEFAULT_SUGGESTIONS = ["projects", "experience", "music", "blog", "contact"];
 const CHAT_RATE_LIMIT_ID = import.meta.env.CHAT_RATE_LIMIT_ID || "chat-api";
 
 let contextCache: ContextChunk[] | null = null;
@@ -113,6 +113,10 @@ function scoreChunk(messageTokens: string[], chunk: ContextChunk) {
   }
 
   if (chunk.type === "blog" && messageTokens.some((token) => ["blog", "post", "writing"].includes(token))) {
+    score += 2;
+  }
+
+  if (chunk.type === "music" && messageTokens.some((token) => ["music", "song", "songs", "album", "albums", "artist", "artists", "listen", "listening"].includes(token))) {
     score += 2;
   }
 
@@ -217,7 +221,7 @@ function validateAssistantPayload(payload: unknown): ChatResponsePayload | null 
 function fallbackResponse(): ChatResponsePayload {
   return {
     message:
-      "I don’t have enough confirmed context for that yet. You can ask about projects, experience, blog posts, or contact details.",
+      "I don’t have enough confirmed context for that yet. You can ask about projects, experience, music, blog posts, or contact details.",
     action: "none",
     suggestions: DEFAULT_SUGGESTIONS,
   };
@@ -244,7 +248,7 @@ async function callModel({ message, history, context }: { message: string; histo
     "Only answer with facts supported by provided context.",
     "If the answer is not in context, say so briefly and suggest relevant sections.",
     "Return JSON only with this shape:",
-    '{"message":"string","action":"scroll|navigate|highlight|none","target":"projects|experience|blog|contact|home(optional when action=none)","suggestions":["projects","experience","blog","contact"]}',
+    '{"message":"string","action":"scroll|navigate|highlight|none","target":"projects|experience|blog|contact|home(optional when action=none)","suggestions":["projects","experience","music","blog","contact"]}',
     "Use action rules:",
     "- scroll: when user asks to see a section on this page",
     "- navigate: when user asks to go to a page/area (blog/home/etc)",

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,6 +1,9 @@
 import type { APIRoute } from "astro";
 import { checkRateLimit } from "@vercel/firewall";
 import bundledContext from "../../../generated/ai-context.json";
+import { musicProfile } from "../../data/music.js";
+import { fetchPinnedGithubData, computeLanguageStats } from "../../utils/github.js";
+import { fetchLastfmData } from "../../utils/lastfm.js";
 
 interface ContextChunk {
   id: string;
@@ -26,6 +29,11 @@ interface ChatMessage {
   content: string;
 }
 
+interface DynamicContextCacheEntry {
+  expiresAt: number;
+  chunks: ContextChunk[];
+}
+
 const ACTION_TARGETS: Record<Exclude<ChatAction, "none">, string[]> = {
   scroll: ["projects", "experience", "blog", "contact", "home"],
   navigate: ["blog", "home", "projects", "experience", "contact"],
@@ -34,8 +42,14 @@ const ACTION_TARGETS: Record<Exclude<ChatAction, "none">, string[]> = {
 
 const DEFAULT_SUGGESTIONS = ["projects", "experience", "music", "blog", "contact"];
 const CHAT_RATE_LIMIT_ID = import.meta.env.CHAT_RATE_LIMIT_ID || "chat-api";
+const GITHUB_CONTEXT_TTL_MS = 30 * 60 * 1000;
+const LASTFM_CONTEXT_TTL_MS = 10 * 60 * 1000;
+const PROJECT_QUERY_TERMS = ["project", "projects", "repo", "repos", "repository", "repositories", "github", "code", "stack", "language", "languages", "built", "build"];
+const MUSIC_QUERY_TERMS = ["music", "song", "songs", "album", "albums", "artist", "artists", "listen", "listening", "track", "tracks", "lastfm"];
 
 let contextCache: ContextChunk[] | null = null;
+let githubContextCache: DynamicContextCacheEntry | null = null;
+let lastfmContextCache: DynamicContextCacheEntry | null = null;
 
 function getAllowedOrigins(requestOrigin: string) {
   const configuredOrigins = String(import.meta.env.CHAT_ALLOWED_ORIGINS || "")
@@ -84,6 +98,196 @@ function normalizeText(value: string) {
     .replace(/[^a-z0-9\s]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function createContextChunk({ id, type, title, content, url, section }: Omit<ContextChunk, "keywords">) {
+  return {
+    id,
+    type,
+    title,
+    content,
+    url,
+    section,
+    keywords: normalizeText([type, title, content, section].filter(Boolean).join(" "))
+      .split(" ")
+      .filter((token) => token.length > 2)
+      .filter((token, index, tokens) => tokens.indexOf(token) === index)
+      .slice(0, 50),
+  };
+}
+
+function messageHasAnyTerm(message: string, terms: string[]) {
+  const normalized = normalizeText(message);
+  return terms.some((term) => normalized.includes(term));
+}
+
+function shouldFetchGithubContext(message: string) {
+  return messageHasAnyTerm(message, PROJECT_QUERY_TERMS);
+}
+
+function shouldFetchMusicContext(message: string) {
+  return messageHasAnyTerm(message, MUSIC_QUERY_TERMS);
+}
+
+async function getGithubRuntimeContext() {
+  if (githubContextCache && githubContextCache.expiresAt > Date.now()) {
+    return githubContextCache.chunks;
+  }
+
+  const githubData = await fetchPinnedGithubData({
+    githubUsername: import.meta.env.GITHUB_USERNAME,
+    githubAccessToken: import.meta.env.GITHUB_ACCESS_TOKEN,
+  });
+
+  if (githubData.error) {
+    throw new Error(githubData.error);
+  }
+
+  const projectChunks = (githubData.projects || [])
+    .filter((repo) => repo.name !== "portfolio")
+    .map((repo) => {
+      const languages = (repo.languages?.edges || [])
+        .map((edge) => edge?.node?.name)
+        .filter(Boolean);
+      const topics = (repo.repositoryTopics?.edges || [])
+        .map((edge) => edge?.node?.topic?.name)
+        .filter(Boolean);
+      const content = [
+        repo.description || "",
+        languages.length ? `Languages: ${languages.join(", ")}.` : "",
+        topics.length ? `Topics: ${topics.join(", ")}.` : "",
+        repo.homepageUrl ? `Homepage: ${repo.homepageUrl}.` : "",
+        repo.latestRelease?.tagName ? `Latest release: ${repo.latestRelease.tagName}.` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+
+      return createContextChunk({
+        id: `runtime-project:${repo.name}`,
+        type: "project",
+        title: repo.name,
+        content,
+        url: repo.url,
+        section: "projects",
+      });
+    });
+
+  const languageStats = computeLanguageStats(githubData.projects || []);
+  if (languageStats.length) {
+    projectChunks.push(
+      createContextChunk({
+        id: "runtime-project:language-stats",
+        type: "project",
+        title: "Pinned project language percentages",
+        content: `Language distribution across pinned projects. ${languageStats
+          .map(
+            (entry) =>
+              `${entry.language}: ${entry.percent}% (${entry.projectCount}/${entry.totalProjects} pinned projects).`,
+          )
+          .join(" ")}`,
+        url: "/#projects",
+        section: "projects",
+      }),
+    );
+  }
+
+  githubContextCache = {
+    expiresAt: Date.now() + GITHUB_CONTEXT_TTL_MS,
+    chunks: projectChunks,
+  };
+
+  return projectChunks;
+}
+
+async function getLastfmRuntimeContext() {
+  if (lastfmContextCache && lastfmContextCache.expiresAt > Date.now()) {
+    return lastfmContextCache.chunks;
+  }
+
+  const lastfmData = await fetchLastfmData({
+    apiKey: import.meta.env.LASTFM_API_KEY,
+    username: import.meta.env.LASTFM_USERNAME || musicProfile.lastfmUsername,
+  });
+
+  if (lastfmData.error) {
+    throw new Error(lastfmData.error);
+  }
+
+  const musicChunks: ContextChunk[] = [];
+
+  if (lastfmData.recentTracks.length) {
+    musicChunks.push(
+      createContextChunk({
+        id: "runtime-music:recent-tracks",
+        type: "music",
+        title: "Recent Last.fm tracks",
+        content: lastfmData.recentTracks
+          .map((track) => `${track.name} by ${track.artist}${track.album ? ` from ${track.album}` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || musicProfile.lastfmUrl,
+        section: "music",
+      }),
+    );
+  }
+
+  if (lastfmData.topArtists.length) {
+    musicChunks.push(
+      createContextChunk({
+        id: "runtime-music:top-artists",
+        type: "music",
+        title: "Top artists this month",
+        content: lastfmData.topArtists
+          .map((artist) => `${artist.name}${artist.playcount ? ` (${artist.playcount} plays)` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || musicProfile.lastfmUrl,
+        section: "music",
+      }),
+    );
+  }
+
+  if (lastfmData.topAlbums.length) {
+    musicChunks.push(
+      createContextChunk({
+        id: "runtime-music:top-albums",
+        type: "music",
+        title: "Top albums this month",
+        content: lastfmData.topAlbums
+          .map((album) => `${album.name} by ${album.artist}${album.playcount ? ` (${album.playcount} plays)` : ""}.`)
+          .join(" "),
+        url: lastfmData.profileUrl || musicProfile.lastfmUrl,
+        section: "music",
+      }),
+    );
+  }
+
+  lastfmContextCache = {
+    expiresAt: Date.now() + LASTFM_CONTEXT_TTL_MS,
+    chunks: musicChunks,
+  };
+
+  return musicChunks;
+}
+
+async function getDynamicContext(message: string) {
+  const dynamicChunks: ContextChunk[] = [];
+
+  if (shouldFetchGithubContext(message)) {
+    try {
+      dynamicChunks.push(...(await getGithubRuntimeContext()));
+    } catch (error) {
+      console.error("GitHub dynamic context failed", error);
+    }
+  }
+
+  if (shouldFetchMusicContext(message)) {
+    try {
+      dynamicChunks.push(...(await getLastfmRuntimeContext()));
+    } catch (error) {
+      console.error("Last.fm dynamic context failed", error);
+    }
+  }
+
+  return dynamicChunks;
 }
 
 function scoreChunk(messageTokens: string[], chunk: ContextChunk) {
@@ -324,7 +528,8 @@ export const POST: APIRoute = async ({ request, url }) => {
     }
 
     const context = await loadContext();
-    const topContext = retrieveTopContext(message, context);
+    const dynamicContext = await getDynamicContext(message);
+    const topContext = retrieveTopContext(message, [...dynamicContext, ...context]);
 
     const rawModelOutput = await callModel({
       message,

--- a/src/pages/api/now-playing.ts
+++ b/src/pages/api/now-playing.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from "astro";
+import { musicProfile } from "../../data/music.js";
+import { fetchLastfmNowPlaying } from "../../utils/lastfm.js";
+
+export const GET: APIRoute = async () => {
+  const data = await fetchLastfmNowPlaying({
+    apiKey: import.meta.env.LASTFM_API_KEY,
+    username: import.meta.env.LASTFM_USERNAME || musicProfile.lastfmUsername,
+  });
+
+  return new Response(
+    JSON.stringify({
+      track: data.track,
+      profileUrl: data.profileUrl,
+    }),
+    {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+};

--- a/src/pages/api/now-playing.ts
+++ b/src/pages/api/now-playing.ts
@@ -2,7 +2,7 @@ import type { APIRoute } from "astro";
 import { musicProfile } from "../../data/music.js";
 import { fetchLastfmNowPlaying } from "../../utils/lastfm.js";
 
-const NOW_PLAYING_TTL_MS = 5 * 60 * 1000;
+const NOW_PLAYING_TTL_MS = 2 * 60 * 1000;
 
 let nowPlayingCache:
   | {

--- a/src/pages/api/now-playing.ts
+++ b/src/pages/api/now-playing.ts
@@ -2,17 +2,43 @@ import type { APIRoute } from "astro";
 import { musicProfile } from "../../data/music.js";
 import { fetchLastfmNowPlaying } from "../../utils/lastfm.js";
 
+const NOW_PLAYING_TTL_MS = 5 * 60 * 1000;
+
+let nowPlayingCache:
+  | {
+      expiresAt: number;
+      payload: {
+        track: Awaited<ReturnType<typeof fetchLastfmNowPlaying>>["track"];
+        profileUrl: string;
+      };
+    }
+  | null = null;
+
 export const GET: APIRoute = async () => {
+  if (nowPlayingCache && nowPlayingCache.expiresAt > Date.now()) {
+    return new Response(JSON.stringify(nowPlayingCache.payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   const data = await fetchLastfmNowPlaying({
     apiKey: import.meta.env.LASTFM_API_KEY,
     username: import.meta.env.LASTFM_USERNAME || musicProfile.lastfmUsername,
   });
 
+  const payload = {
+    track: data.track,
+    profileUrl: data.profileUrl,
+  };
+
+  nowPlayingCache = {
+    expiresAt: Date.now() + NOW_PLAYING_TTL_MS,
+    payload,
+  };
+
   return new Response(
-    JSON.stringify({
-      track: data.track,
-      profileUrl: data.profileUrl,
-    }),
+    JSON.stringify(payload),
     {
       status: 200,
       headers: { "Content-Type": "application/json" },

--- a/src/pages/api/now-playing.ts
+++ b/src/pages/api/now-playing.ts
@@ -22,9 +22,19 @@ export const GET: APIRoute = async () => {
     });
   }
 
+  const hasToken = Boolean(import.meta.env.LASTFM_API_KEY);
+  if (!hasToken) {
+    console.warn("/api/now-playing called without LASTFM_API_KEY");
+  }
+
   const data = await fetchLastfmNowPlaying({
     apiKey: import.meta.env.LASTFM_API_KEY,
     username: import.meta.env.LASTFM_USERNAME || musicProfile.lastfmUsername,
+  });
+  console.log("/api/now-playing result", {
+    hasToken,
+    nowPlaying: Boolean(data.track),
+    track: data.track ? { name: data.track.name, artist: data.track.artist } : null,
   });
 
   const payload = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -79,7 +79,7 @@ const avatarUrl = githubData.avatarUrl;
         >
           Schedule a call below, or connect with me on <a
             href="https://www.linkedin.com/in/bostonrohan/"
-            class="flex items-center gap-1 underline text-[#2572B1]"
+            class="flex items-center gap-1 underline text-[var(--color-link)]"
             ><Icon name="linkedin" />LinkedIn</a
           > or <a
             href="https://github.com/BostonRohan"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,54 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+:root {
+  --color-bg: #f8fafc;
+  --color-surface: rgba(255, 255, 255, 0.8);
+  --color-surface-muted: #e2e8f0;
+  --color-surface-strong: #e2e8f0;
+  --color-border: rgba(148, 163, 184, 0.45);
+  --color-text: #0f172a;
+  --color-text-strong: #020617;
+  --color-text-muted: #475569;
+  --color-brand: #9a3412;
+  --color-brand-strong: #c2410c;
+  --color-link: #0072b1;
+  --color-link-soft: #dbeafe;
+  --color-live: #059669;
+  --color-live-soft: #d1fae5;
+  --color-live-contrast: #064e3b;
+  --color-info: #0369a1;
+  --color-info-soft: #e0f2fe;
+  --color-info-contrast: #0c4a6e;
+  --color-warning: #b45309;
+  --color-warning-soft: #fef3c7;
+  --color-warning-contrast: #78350f;
+}
+
+.dark {
+  --color-bg: #18181b;
+  --color-surface: rgba(24, 24, 27, 0.78);
+  --color-surface-muted: rgba(39, 39, 42, 0.72);
+  --color-surface-strong: #3f3f46;
+  --color-border: rgba(63, 63, 70, 0.9);
+  --color-text: #e5e7eb;
+  --color-text-strong: #fafafa;
+  --color-text-muted: #a1a1aa;
+  --color-brand: #fdba74;
+  --color-brand-strong: #fb923c;
+  --color-link: #0072b1;
+  --color-link-soft: rgba(37, 99, 235, 0.18);
+  --color-live: #6ee7b7;
+  --color-live-soft: rgba(16, 185, 129, 0.2);
+  --color-live-contrast: #d1fae5;
+  --color-info: #7dd3fc;
+  --color-info-soft: rgba(14, 165, 233, 0.18);
+  --color-info-contrast: #e0f2fe;
+  --color-warning: #fbbf24;
+  --color-warning-soft: rgba(251, 191, 36, 0.18);
+  --color-warning-contrast: #fef3c7;
+}
+
 @keyframes ai-highlight-pulse {
   0% {
     box-shadow: 0 0 0 0 rgba(251, 146, 60, 0.45);
@@ -16,4 +64,208 @@
 .ai-highlight {
   border-radius: 1rem;
   animation: ai-highlight-pulse 1.2s ease-out 1;
+}
+
+@keyframes music-note-float {
+  0% {
+    transform: translate3d(0, 8px, 0) rotate(-14deg) scale(0.72);
+    opacity: 0;
+  }
+  18% {
+    opacity: 0.88;
+  }
+  50% {
+    transform: translate3d(2px, 0, 0) rotate(8deg) scale(1);
+    opacity: 1;
+  }
+  82% {
+    opacity: 0.72;
+  }
+  100% {
+    transform: translate3d(-1px, -8px, 0) rotate(-8deg) scale(0.78);
+    opacity: 0;
+  }
+}
+
+@keyframes music-gradient-shift {
+  0%,
+  100% {
+    transform: scale(1) rotate(0deg);
+    opacity: 0.95;
+  }
+  50% {
+    transform: scale(1.06) rotate(6deg);
+    opacity: 1;
+  }
+}
+
+.music-now-playing {
+  position: relative;
+  overflow: hidden;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--color-live) 30%, transparent);
+  background:
+    radial-gradient(circle at 20% 50%, color-mix(in srgb, var(--color-live) 22%, transparent), transparent 42%),
+    radial-gradient(circle at 78% 32%, color-mix(in srgb, var(--color-live) 16%, white 10%), transparent 38%),
+    linear-gradient(135deg, color-mix(in srgb, var(--color-live-soft) 50%, white 80%), color-mix(in srgb, var(--color-live-soft) 75%, white 68%));
+  color: var(--color-live-contrast);
+  box-shadow: 0 10px 30px color-mix(in srgb, var(--color-live) 12%, transparent);
+  max-width: 15rem;
+}
+
+.dark .music-now-playing {
+  border-color: rgb(16 185 129 / 0.26);
+  background:
+    radial-gradient(circle at 20% 50%, rgb(16 185 129 / 0.26), transparent 42%),
+    radial-gradient(circle at 78% 32%, rgb(52 211 153 / 0.18), transparent 38%),
+    linear-gradient(135deg, rgb(5 46 22 / 0.78), rgb(6 78 59 / 0.62));
+  color: rgb(209 250 229);
+  box-shadow: 0 14px 36px rgb(0 0 0 / 0.24);
+}
+
+.music-now-playing-mobile {
+  width: 1.5rem;
+  height: 1.5rem;
+  max-width: none;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.music-now-playing::before {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  background:
+    radial-gradient(circle at 30% 30%, rgb(255 255 255 / 0.22), transparent 30%),
+    radial-gradient(circle at 70% 60%, color-mix(in srgb, var(--color-live) 16%, transparent), transparent 32%);
+  animation: music-gradient-shift 5s ease-in-out infinite;
+}
+
+.music-now-playing-copy {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  gap: 0.05rem;
+  line-height: 1.05;
+}
+
+.music-now-playing-label {
+  font-size: 0.55rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  opacity: 0.78;
+}
+
+.music-note-cloud {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 9999px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 30% 30%, rgb(255 255 255 / 0.42), transparent 36%),
+    linear-gradient(145deg, rgb(255 255 255 / 0.22), color-mix(in srgb, var(--color-live) 10%, transparent));
+}
+
+.music-note-cloud-mobile {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.music-note-cloud::before {
+  content: "";
+  position: absolute;
+  inset: 0.16rem;
+  border-radius: 9999px;
+  border: 1px solid color-mix(in srgb, var(--color-live) 18%, transparent);
+}
+
+.music-note-track {
+  position: absolute;
+  inset: 0.16rem;
+  overflow: hidden;
+  border-radius: 9999px;
+}
+
+.music-note {
+  position: absolute;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  left: 50%;
+  top: 50%;
+  color: var(--color-live);
+  text-shadow: 0 0 12px color-mix(in srgb, var(--color-live) 25%, transparent);
+  transform: translate(-50%, -50%);
+  animation: music-note-float 1.85s ease-in-out infinite;
+  font-size: 0.9rem;
+}
+
+.music-note-one {
+  animation-delay: 0s;
+}
+
+.music-note-two {
+  margin-left: 0.22rem;
+  animation-delay: -0.62s;
+}
+
+.music-note-three {
+  margin-left: -0.22rem;
+  animation-delay: -1.24s;
+}
+
+.music-popover {
+  z-index: 30;
+  border: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 92%, white 8%);
+  color: var(--color-text);
+  box-shadow: 0 16px 40px rgb(15 23 42 / 0.14);
+  backdrop-filter: blur(18px);
+  transform: translateX(0);
+}
+
+.music-popover-mobile {
+  transform: translateX(-50%);
+}
+
+.dark .music-popover {
+  background: color-mix(in srgb, var(--color-surface-muted) 94%, black 6%);
+  color: var(--color-text);
+  box-shadow: 0 18px 44px rgb(0 0 0 / 0.32);
+}
+
+.music-popover-label {
+  font-size: 0.625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.music-popover-title {
+  margin-top: 0.35rem;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  color: var(--color-text-strong);
+}
+
+.music-popover-meta {
+  margin-top: 0.2rem;
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.music-popover-link {
+  display: inline-flex;
+  margin-top: 0.7rem;
+  font-size: 0.8rem;
+  color: var(--color-link);
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
 }

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -49,6 +49,9 @@ const PinnedProjectSchema = z.object({
 });
 
 const PinnedProjectListSchema = z.array(PinnedProjectSchema);
+const GITHUB_PINNED_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+let pinnedGithubCache = null;
 
 const PINNED_REPOS_QUERY = (githubUsername) => `
 {
@@ -99,6 +102,10 @@ export async function fetchPinnedGithubData({
   githubUsername,
   githubAccessToken,
 }) {
+  if (pinnedGithubCache && pinnedGithubCache.expiresAt > Date.now()) {
+    return pinnedGithubCache.value;
+  }
+
   if (!githubUsername || !githubAccessToken) {
     return {
       githubUserId: null,
@@ -157,12 +164,19 @@ export async function fetchPinnedGithubData({
       };
     }
 
-    return {
+    const result = {
       githubUserId: json?.data?.user?.id || null,
       avatarUrl: json?.data?.user?.avatarUrl || null,
       projects: parsedProjects.data,
       error: null,
     };
+
+    pinnedGithubCache = {
+      expiresAt: Date.now() + GITHUB_PINNED_CACHE_TTL_MS,
+      value: result,
+    };
+
+    return result;
   } catch (error) {
     return {
       githubUserId: null,

--- a/src/utils/lastfm.js
+++ b/src/utils/lastfm.js
@@ -1,0 +1,159 @@
+const LASTFM_API_BASE = "https://ws.audioscrobbler.com/2.0/";
+
+function normalizeArray(value) {
+  return Array.isArray(value) ? value : value ? [value] : [];
+}
+
+function createLastfmUrl(username) {
+  return `https://www.last.fm/user/${username}`;
+}
+
+async function fetchLastfmMethod({ apiKey, username, method, limit = 5, period }) {
+  if (!apiKey || !username) {
+    return null;
+  }
+
+  const searchParams = new URLSearchParams({
+    method,
+    user: username,
+    api_key: apiKey,
+    format: "json",
+    limit: String(limit),
+  });
+
+  if (period) {
+    searchParams.set("period", period);
+  }
+
+  const response = await fetch(`${LASTFM_API_BASE}?${searchParams.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Last.fm request failed (${response.status}) for ${method}`);
+  }
+
+  return response.json();
+}
+
+export async function fetchLastfmData({
+  apiKey,
+  username,
+  recentTrackLimit = 5,
+  topArtistLimit = 6,
+  topAlbumLimit = 6,
+} = {}) {
+  const emptyData = {
+    username,
+    profileUrl: username ? createLastfmUrl(username) : "",
+    recentTracks: [],
+    topArtists: [],
+    topAlbums: [],
+    error: null,
+  };
+
+  if (!apiKey || !username) {
+    return {
+      ...emptyData,
+      error: "Missing Last.fm credentials",
+    };
+  }
+
+  try {
+    const [recentTracksResponse, topArtistsResponse, topAlbumsResponse] = await Promise.all([
+      fetchLastfmMethod({
+        apiKey,
+        username,
+        method: "user.getrecenttracks",
+        limit: recentTrackLimit,
+      }),
+      fetchLastfmMethod({
+        apiKey,
+        username,
+        method: "user.gettopartists",
+        period: "1month",
+        limit: topArtistLimit,
+      }),
+      fetchLastfmMethod({
+        apiKey,
+        username,
+        method: "user.gettopalbums",
+        period: "1month",
+        limit: topAlbumLimit,
+      }),
+    ]);
+
+    return {
+      ...emptyData,
+      recentTracks: normalizeArray(recentTracksResponse?.recenttracks?.track).map((track) => ({
+        name: track?.name || "",
+        artist: track?.artist?.["#text"] || "",
+        album: track?.album?.["#text"] || "",
+        url: track?.url || "",
+        nowPlaying: track?.["@attr"]?.nowplaying === "true",
+        playedAt: track?.date?.["#text"] || "",
+      })),
+      topArtists: normalizeArray(topArtistsResponse?.topartists?.artist).map((artist) => ({
+        name: artist?.name || "",
+        playcount: artist?.playcount || "",
+        url: artist?.url || "",
+      })),
+      topAlbums: normalizeArray(topAlbumsResponse?.topalbums?.album).map((album) => ({
+        name: album?.name || "",
+        artist:
+          typeof album?.artist === "string"
+            ? album.artist
+            : album?.artist?.name || "",
+        playcount: album?.playcount || "",
+        url: album?.url || "",
+      })),
+    };
+  } catch (error) {
+    return {
+      ...emptyData,
+      error: error instanceof Error ? error.message : "Failed to fetch Last.fm data",
+    };
+  }
+}
+
+export async function fetchLastfmNowPlaying({ apiKey, username } = {}) {
+  const emptyData = {
+    username,
+    profileUrl: username ? createLastfmUrl(username) : "",
+    track: null,
+    error: null,
+  };
+
+  if (!apiKey || !username) {
+    return {
+      ...emptyData,
+      error: "Missing Last.fm credentials",
+    };
+  }
+
+  try {
+    const recentTracksResponse = await fetchLastfmMethod({
+      apiKey,
+      username,
+      method: "user.getrecenttracks",
+      limit: 1,
+    });
+    const track = normalizeArray(recentTracksResponse?.recenttracks?.track)[0];
+
+    if (!track || track?.["@attr"]?.nowplaying !== "true") {
+      return emptyData;
+    }
+
+    return {
+      ...emptyData,
+      track: {
+        name: track?.name || "",
+        artist: track?.artist?.["#text"] || "",
+        album: track?.album?.["#text"] || "",
+        url: track?.url || "",
+      },
+    };
+  } catch (error) {
+    return {
+      ...emptyData,
+      error: error instanceof Error ? error.message : "Failed to fetch Last.fm now playing",
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add runtime Last.fm presence in the nav, including a desktop listening pill, mobile popover, explicit-title sanitization, and a cached `/api/now-playing` route
- stop baking volatile GitHub and Last.fm data into `generated/ai-context.json`, and instead fetch fresh project/music context inside `/api/chat` with short TTL caching
- address follow-up review issues by generating `ai-context.json` before `pnpm start`, removing duplicated user prompts in chat history, and caching pinned GitHub data for homepage/runtime consumers

## Testing
- not rerun after the latest review follow-ups