### PR TITLE
Sanitize Last.fm now-playing and assistant responses

### DIFF
--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -451,6 +451,7 @@ async function callModel({ message, history, context }: { message: string; histo
     "You are Boston Rohan's portfolio assistant.",
     "Only answer with facts supported by provided context.",
     "If the answer is not in context, say so briefly and suggest relevant sections.",
+    "Avoid explicit language and profanity in your responses.",
     "Return JSON only with this shape:",
     '{"message":"string","action":"scroll|navigate|highlight|none","target":"projects|experience|blog|contact|home(optional when action=none)","suggestions":["projects","experience","music","blog","contact"]}',
     "Use action rules:",

--- a/src/utils/lastfm.js
+++ b/src/utils/lastfm.js
@@ -1,5 +1,18 @@
 const LASTFM_API_BASE = "https://ws.audioscrobbler.com/2.0/";
 
+async function sanitizeText(input) {
+  if (!input || typeof input !== "string") return input || "";
+  try {
+    const response = await fetch(`https://www.purgomalum.com/service/json?text=${encodeURIComponent(input)}`);
+    if (!response.ok) return input;
+    const json = await response.json();
+    return json?.result ?? input;
+  } catch (error) {
+    console.error("Sanitization failed", error);
+    return input;
+  }
+}
+
 function normalizeArray(value) {
   return Array.isArray(value) ? value : value ? [value] : [];
 }
@@ -141,12 +154,18 @@ export async function fetchLastfmNowPlaying({ apiKey, username } = {}) {
       return emptyData;
     }
 
+    const [name, artist, album] = await Promise.all([
+      sanitizeText(track?.name),
+      sanitizeText(track?.artist?.["#text"]),
+      sanitizeText(track?.album?.["#text"]),
+    ]);
+
     return {
       ...emptyData,
       track: {
-        name: track?.name || "",
-        artist: track?.artist?.["#text"] || "",
-        album: track?.album?.["#text"] || "",
+        name,
+        artist,
+        album,
         url: track?.url || "",
       },
     };


### PR DESCRIPTION
This PR adds sanitization to Last.fm now-playing data and updates the assistant's system prompt to avoid explicit language in responses.

Key changes:
- In `src/utils/lastfm.js`, `fetchLastfmNowPlaying` now uses the external PurgoMalum API to sanitize track, artist, and album names.
- In `src/pages/api/chat.ts`, the system prompt for the model was updated with a clear instruction to avoid explicit language and profanity in its responses.
- Per-field sanitization was omitted from `fetchLastfmData` to maintain performance, as the LLM is expected to handle sanitization for that data based on its updated instructions.