### PR TITLE
Improve assistant context logging and UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,220 @@
+# AGENTS.md
+
+This file provides guidance for AI agents working in this repository.
+
+## Project Overview
+
+- **Type**: Personal portfolio website
+- **Framework**: Astro 5.x with React 18, Svelte 5, and Tailwind CSS v4
+- **Runtime**: Node 24.x (uses ES modules with `"type": "module"`)
+- **Hosting**: Vercel (server-side rendering)
+
+## Commands
+
+### Development
+
+```bash
+npm run dev       # Start development server
+npm run start     # Alias for astro dev
+npm run preview   # Preview production build locally
+```
+
+### Building
+
+```bash
+npm run build     # Generate AI context + build for production
+npm run astro     # Run Astro CLI commands
+```
+
+### Code Generation
+
+```bash
+npm run generate:ai-context   # Generate context JSON for AI assistant
+```
+
+**Note**: `predev` and `prestart` automatically run the AI context generation script.
+
+### Formatting
+
+```bash
+npx prettier --write .   # Format all files
+npx prettier --check .   # Check formatting without writing
+```
+
+This project uses Prettier with the `prettier-plugin-astro` plugin. Configuration is in `.prettierrc.cjs`.
+
+### Linting/Type Checking
+
+```bash
+npx astro check   # Run TypeScript type checking
+```
+
+**Note**: There are no ESLint or unit tests configured. The project relies on Prettier for formatting and `astro check` for type safety.
+
+## Code Style Guidelines
+
+### General
+
+- Use ES modules (`import`/`export`) - the project uses `"type": "module"` in package.json
+- Use strict TypeScript (extends `astro/tsconfigs/strict`)
+- Prefer functional components and hooks over classes
+- Avoid `any` types - use `unknown` when type is uncertain, then narrow
+
+### TypeScript
+
+- **Interfaces over types** for object shapes (e.g., `interface Project {...}`)
+- **Type aliases** for unions, tuples, and primitives
+- Use `type` for utility types like `Record<K, V>`, `Partial<T>`, etc.
+- Always type function parameters and return values
+- Use `strict` mode enabled in tsconfig.json
+
+### Imports
+
+**Order:**
+
+1. External libraries (React, Astro, etc.)
+2. Internal utilities/functions
+3. Components (relative paths)
+4. Styles/assets
+
+**Example:**
+
+```typescript
+import { useState, useEffect } from "react";
+import type { APIRoute } from "astro";
+import { fetchData } from "../../utils/data";
+import Nav from "../components/react/Nav";
+import styles from "./Component.module.css";
+```
+
+- Use absolute paths for internal modules (e.g., `src/utils/`)
+- Use explicit file extensions in imports (`.tsx`, `.ts`, `.astro`)
+- Use `import type` for type-only imports
+
+### Naming Conventions
+
+- **Components**: PascalCase (e.g., `PortfolioAssistant.tsx`, `Card.astro`)
+- **Files/utilities**: camelCase (e.g., `github.ts`, `blogs.ts`)
+- **Interfaces**: PascalCase with descriptive names (e.g., `NowPlayingTrack`)
+- **Constants**: UPPER_SNAKE_CASE for compile-time constants (e.g., `DEFAULT_SUGGESTIONS`)
+- **Variables/functions**: camelCase
+- **Boolean variables**: Use `is`, `has`, `can` prefixes (e.g., `isLoading`, `hasError`)
+
+### React/Component Patterns
+
+- Use functional components with hooks
+- Destructure props in function signature when possible
+- Use `useEffect` cleanup functions for event listeners and subscriptions
+- Use `client:load` or `client:visible` directives for interactive React components in Astro
+- Handle loading/error states explicitly
+
+**Example:**
+
+```typescript
+export default function Component({ title }: { title: string }) {
+  const [state, setState] = useState<string>("");
+
+  useEffect(() => {
+    let isMounted = true;
+    async function fetchData() {
+      const data = await loadData();
+      if (isMounted) setState(data);
+    }
+    void fetchData();
+    return () => { isMounted = false; };
+  }, []);
+
+  return <div>{state}</div>;
+}
+```
+
+### Error Handling
+
+- Use try/catch blocks for async operations
+- Let errors propagate with meaningful messages in utility functions
+- Log errors to console with descriptive messages
+- Use Sentry for production error tracking (imported from `@sentry/astro`)
+- Return early on error conditions
+
+**Example:**
+
+```typescript
+async function fetchData() {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch: ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    console.error("Fetch failed", error);
+    throw error;
+  }
+}
+```
+
+### Astro Components
+
+- Frontmatter at top with `---` fences
+- Put imports and logic in frontmatter
+- Template in HTML-like syntax below frontmatter
+- Use `client:*` directives only when needed for interactivity
+
+### Tailwind CSS
+
+- Use Tailwind v4 with `@tailwindcss/vite` plugin
+- Dark mode via `dark` class on `html` element
+- Use semantic class names where possible
+- Use `dark:` prefix for dark mode variants
+
+### State Management
+
+- Use **nanostores** (`nanostores` package) for global state (see `src/store.js`)
+- Use React `useState` for component-local state
+- Use `useEffect` for side effects
+
+### API Routes
+
+- Use Astro's `APIRoute` type for endpoint functions
+- Return `Response` objects with appropriate headers
+- Validate request bodies before processing
+- Handle CORS with origin checking for production APIs
+
+### File Organization
+
+```
+src/
+├── components/       # Astro and React components
+│   └── react/       # React-specific components
+├── data/            # Static data (portfolio info, config)
+├── icons/           # Icon assets
+├── layouts/         # Astro layouts
+├── pages/           # Astro pages and API routes
+│   └── api/        # Server-side API endpoints
+├── store.js        # Global nanostore state
+├── styles/         # Global CSS
+└── utils/          # Utility functions
+```
+
+### Git/Version Control
+
+- Keep `.env` files local - never commit secrets
+- Use conventional commit messages if contributing
+- The `.gitignore` excludes `dist/`, `node_modules/`, `.env`
+
+### Environment Variables
+
+Required variables (check `.env` for defaults):
+
+- `GITHUB_USERNAME`, `GITHUB_ACCESS_TOKEN` - GitHub API
+- `SENTRY_DSN`, `SENTRY_AUTH_TOKEN` - Error tracking
+- `AI_GATEWAY_API_KEY` - AI chat functionality
+- `ANILIST_USERNAME` - Anime data
+- `LASTFM_API_KEY`, `LASTFM_USERNAME` - Music data
+
+### Additional Notes
+
+- The project generates `generated/ai-context.json` at build time for the AI assistant
+- Run `npm run generate:ai-context` after adding new content (projects, blog posts, etc.)
+- The AI chat endpoint (`/api/chat`) uses rate limiting via Vercel Firewall
+- Pre-commit hooks are not configured - rely on manual Prettier usage

--- a/src/components/react/PortfolioAssistant.tsx
+++ b/src/components/react/PortfolioAssistant.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { assistantIntro, suggestedPrompts } from "../../data/portfolio.js";
 
@@ -77,6 +77,15 @@ export default function PortfolioAssistant({ imageUrl }: { imageUrl?: string }) 
   const [isLoading, setIsLoading] = useState(false);
 
   const quickPrompts = useMemo(() => suggestedPrompts, []);
+
+  const logRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = logRef.current;
+    if (!container) return;
+
+    container.scrollTo({ top: container.scrollHeight, behavior: "smooth" });
+  }, [messages, isLoading]);
 
   async function submitPrompt(rawMessage: string) {
     const message = rawMessage.trim();
@@ -161,7 +170,11 @@ export default function PortfolioAssistant({ imageUrl }: { imageUrl?: string }) 
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto space-y-3 pr-1" aria-live="polite">
+      <div
+        ref={logRef}
+        className="flex-1 min-h-0 overflow-y-auto space-y-3 pr-1"
+        aria-live="polite"
+      >
         {messages.map((message, index) => (
           <article
             key={`${message.role}-${index}`}
@@ -177,23 +190,32 @@ export default function PortfolioAssistant({ imageUrl }: { imageUrl?: string }) 
 
         {isLoading && (
           <article className="rounded-xl px-3 py-2 text-sm sm:text-base bg-slate-100 dark:bg-zinc-800 max-w-full">
-            <p>Thinking...</p>
+            <p className="inline-flex items-center gap-1">
+              Thinking
+              <span className="ai-thinking-dots" aria-hidden="true">
+                <span>.</span>
+                <span>.</span>
+                <span>.</span>
+              </span>
+            </p>
           </article>
         )}
       </div>
 
-      <div className="flex flex-wrap gap-2">
-        {quickPrompts.map((prompt) => (
-          <button
-            key={prompt}
-            type="button"
-            className="rounded-full border border-slate-300 dark:border-zinc-700 px-3 py-1 text-xs sm:text-sm hover:bg-slate-100 dark:hover:bg-zinc-800 transition"
-            onClick={() => submitPrompt(prompt)}
-            disabled={isLoading}
-          >
-            {prompt}
-          </button>
-        ))}
+      <div className="overflow-x-auto pb-1">
+        <div className="flex gap-2 flex-nowrap">
+          {quickPrompts.map((prompt) => (
+            <button
+              key={prompt}
+              type="button"
+              className="rounded-full border border-slate-300 dark:border-zinc-700 px-3 py-1 text-xs sm:text-sm hover:bg-slate-100 dark:hover:bg-zinc-800 transition flex-shrink-0 whitespace-nowrap"
+              onClick={() => submitPrompt(prompt)}
+              disabled={isLoading}
+            >
+              {prompt}
+            </button>
+          ))}
+        </div>
       </div>
 
       <form className="flex gap-2" onSubmit={onSubmit}>

--- a/src/data/portfolio.js
+++ b/src/data/portfolio.js
@@ -121,10 +121,8 @@ export const assistantIntro =
   "Self taught developer currently working at Elevation Church. I love to code, listen to music, and watch anime. Ask about projects, work, blog posts, or what is in the current music rotation.";
 
 export const suggestedPrompts = [
-  "what language dominates your pinned projects",
-  "what have you been listening to lately",
-  "who are your top artists this month",
   "what projects have you built",
   "what technologies do you use",
-  "show me your blog",
+  "what have you been listening to lately",
+  "what are your favorite anime",
 ];

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -3,12 +3,23 @@ import * as Sentry from "@sentry/astro";
 import { checkRateLimit } from "@vercel/firewall";
 import bundledContext from "../../../generated/ai-context.json";
 import { musicProfile } from "../../data/music.js";
-import { fetchPinnedGithubData, computeLanguageStats } from "../../utils/github.js";
+import {
+  fetchPinnedGithubData,
+  computeLanguageStats,
+} from "../../utils/github.js";
 import { fetchLastfmData } from "../../utils/lastfm.js";
+import { fetchAnilistData } from "../../utils/anilist.js";
 
 interface ContextChunk {
   id: string;
-  type: "bio" | "project" | "experience" | "blog" | "contact" | "music";
+  type:
+    | "bio"
+    | "project"
+    | "experience"
+    | "blog"
+    | "contact"
+    | "music"
+    | "anime";
   title?: string;
   content: string;
   url?: string;
@@ -35,22 +46,80 @@ interface DynamicContextCacheEntry {
   chunks: ContextChunk[];
 }
 
+interface DynamicContextSource {
+  name: string;
+  shouldInclude?: (message: string) => boolean;
+  loader: () => Promise<ContextChunk[]>;
+}
+
 const ACTION_TARGETS: Record<Exclude<ChatAction, "none">, string[]> = {
   scroll: ["projects", "experience", "blog", "contact", "home"],
   navigate: ["blog", "home", "projects", "experience", "contact"],
   highlight: ["projects", "experience", "blog", "contact"],
 };
 
-const DEFAULT_SUGGESTIONS = ["projects", "experience", "music", "blog", "contact"];
+const DEFAULT_SUGGESTIONS = [
+  "projects",
+  "experience",
+  "music",
+  "blog",
+  "contact",
+];
 const CHAT_RATE_LIMIT_ID = import.meta.env.CHAT_RATE_LIMIT_ID || "chat-api";
-const GITHUB_CONTEXT_TTL_MS = 30 * 60 * 1000;
+const GITHUB_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
 const LASTFM_CONTEXT_TTL_MS = 10 * 60 * 1000;
-const PROJECT_QUERY_TERMS = ["project", "projects", "repo", "repos", "repository", "repositories", "github", "code", "stack", "language", "languages", "built", "build"];
-const MUSIC_QUERY_TERMS = ["music", "song", "songs", "album", "albums", "artist", "artists", "listen", "listening", "track", "tracks", "lastfm"];
+const ANILIST_CONTEXT_TTL_MS = 24 * 60 * 60 * 1000;
+const PROJECT_QUERY_TERMS = [
+  "project",
+  "projects",
+  "repo",
+  "repos",
+  "repository",
+  "repositories",
+  "github",
+  "code",
+  "stack",
+  "language",
+  "languages",
+  "built",
+  "build",
+];
+const MUSIC_QUERY_TERMS = [
+  "music",
+  "song",
+  "songs",
+  "album",
+  "albums",
+  "artist",
+  "artists",
+  "listen",
+  "listening",
+  "track",
+  "tracks",
+  "lastfm",
+];
+const ANIME_QUERY_TERMS = [
+  "anime",
+  "manga",
+  "show",
+  "shows",
+  "watching",
+  "reading",
+  "anilist",
+  "otaku",
+  "favorite",
+  "genre",
+  "genres",
+  "film",
+  "films",
+  "movie",
+  "movies",
+];
 
 let contextCache: ContextChunk[] | null = null;
 let githubContextCache: DynamicContextCacheEntry | null = null;
 let lastfmContextCache: DynamicContextCacheEntry | null = null;
+let anilistContextCache: DynamicContextCacheEntry | null = null;
 
 function getAllowedOrigins(requestOrigin: string) {
   const configuredOrigins = String(import.meta.env.CHAT_ALLOWED_ORIGINS || "")
@@ -85,7 +154,9 @@ function isAllowedOrigin(request: Request, serverOrigin: string) {
 
 async function isRateLimited(request: Request) {
   try {
-    const { rateLimited } = await checkRateLimit(CHAT_RATE_LIMIT_ID, { request });
+    const { rateLimited } = await checkRateLimit(CHAT_RATE_LIMIT_ID, {
+      request,
+    });
     return rateLimited;
   } catch (error) {
     Sentry.captureException(error, {
@@ -104,7 +175,14 @@ function normalizeText(value: string) {
     .trim();
 }
 
-function createContextChunk({ id, type, title, content, url, section }: Omit<ContextChunk, "keywords">) {
+function createContextChunk({
+  id,
+  type,
+  title,
+  content,
+  url,
+  section,
+}: Omit<ContextChunk, "keywords">) {
   return {
     id,
     type,
@@ -112,7 +190,9 @@ function createContextChunk({ id, type, title, content, url, section }: Omit<Con
     content,
     url,
     section,
-    keywords: normalizeText([type, title, content, section].filter(Boolean).join(" "))
+    keywords: normalizeText(
+      [type, title, content, section].filter(Boolean).join(" "),
+    )
       .split(" ")
       .filter((token) => token.length > 2)
       .filter((token, index, tokens) => tokens.indexOf(token) === index)
@@ -134,9 +214,12 @@ function shouldFetchMusicContext(message: string) {
 }
 
 async function getGithubRuntimeContext() {
-  if (githubContextCache && githubContextCache.expiresAt > Date.now()) {
+  const cacheHit = githubContextCache && githubContextCache.expiresAt > Date.now();
+  if (cacheHit) {
+    console.info("[dynamic-context-cache] github hit");
     return githubContextCache.chunks;
   }
+  console.info("[dynamic-context-cache] github miss");
 
   const githubData = await fetchPinnedGithubData({
     githubUsername: import.meta.env.GITHUB_USERNAME,
@@ -165,7 +248,9 @@ async function getGithubRuntimeContext() {
         languages.length ? `Languages: ${languages.join(", ")}.` : "",
         topics.length ? `Topics: ${topics.join(", ")}.` : "",
         repo.homepageUrl ? `Homepage: ${repo.homepageUrl}.` : "",
-        repo.latestRelease?.tagName ? `Latest release: ${repo.latestRelease.tagName}.` : "",
+        repo.latestRelease?.tagName
+          ? `Latest release: ${repo.latestRelease.tagName}.`
+          : "",
       ]
         .filter(Boolean)
         .join(" ");
@@ -208,9 +293,12 @@ async function getGithubRuntimeContext() {
 }
 
 async function getLastfmRuntimeContext() {
-  if (lastfmContextCache && lastfmContextCache.expiresAt > Date.now()) {
+  const cacheHit = lastfmContextCache && lastfmContextCache.expiresAt > Date.now();
+  if (cacheHit) {
+    console.info("[dynamic-context-cache] lastfm hit");
     return lastfmContextCache.chunks;
   }
+  console.info("[dynamic-context-cache] lastfm miss");
 
   const lastfmData = await fetchLastfmData({
     apiKey: import.meta.env.LASTFM_API_KEY,
@@ -234,7 +322,10 @@ async function getLastfmRuntimeContext() {
         type: "music",
         title: "Recent Last.fm tracks",
         content: lastfmData.recentTracks
-          .map((track) => `${track.name} by ${track.artist}${track.album ? ` from ${track.album}` : ""}${track.nowPlaying ? " (Currently playing)" : ""}.`)
+          .map(
+            (track) =>
+              `${track.name} by ${track.artist}${track.album ? ` from ${track.album}` : ""}${track.nowPlaying ? " (Currently playing)" : ""}.`,
+          )
           .join(" "),
         url: lastfmData.profileUrl || musicProfile.lastfmUrl,
         section: "music",
@@ -249,7 +340,10 @@ async function getLastfmRuntimeContext() {
         type: "music",
         title: "Top artists this month",
         content: lastfmData.topArtists
-          .map((artist) => `${artist.name}${artist.playcount ? ` (${artist.playcount} plays)` : ""}.`)
+          .map(
+            (artist) =>
+              `${artist.name}${artist.playcount ? ` (${artist.playcount} plays)` : ""}.`,
+          )
           .join(" "),
         url: lastfmData.profileUrl || musicProfile.lastfmUrl,
         section: "music",
@@ -264,7 +358,10 @@ async function getLastfmRuntimeContext() {
         type: "music",
         title: "Top albums this month",
         content: lastfmData.topAlbums
-          .map((album) => `${album.name} by ${album.artist}${album.playcount ? ` (${album.playcount} plays)` : ""}.`)
+          .map(
+            (album) =>
+              `${album.name} by ${album.artist}${album.playcount ? ` (${album.playcount} plays)` : ""}.`,
+          )
           .join(" "),
         url: lastfmData.profileUrl || musicProfile.lastfmUrl,
         section: "music",
@@ -280,31 +377,137 @@ async function getLastfmRuntimeContext() {
   return musicChunks;
 }
 
+async function getAnilistRuntimeContext() {
+  const cacheHit = anilistContextCache && anilistContextCache.expiresAt > Date.now();
+  if (cacheHit) {
+    console.info("[dynamic-context-cache] anilist hit");
+    return anilistContextCache.chunks;
+  }
+  console.info("[dynamic-context-cache] anilist miss");
+
+  const anilistData = await fetchAnilistData(
+    import.meta.env.ANILIST_USERNAME || "bosston",
+  );
+
+  if (anilistData.error) {
+    const error = new Error(`AniList context failed: ${anilistData.error}`);
+    Sentry.captureException(error, {
+      tags: { service: "anilist", method: "getAnilistRuntimeContext" },
+    });
+    throw error;
+  }
+
+  const animeChunks: ContextChunk[] = [];
+
+  if (anilistData.favorites.anime.length) {
+    animeChunks.push(
+      createContextChunk({
+        id: "runtime-anime:favorite-anime",
+        type: "anime",
+        title: "Favorite Anime",
+        content: `Boston's favorite anime: ${anilistData.favorites.anime.join(", ")}.`,
+        url: `https://anilist.co/user/${anilistData.userName}/animelist`,
+        section: "anime",
+      }),
+    );
+  }
+
+  if (anilistData.topGenres.length) {
+    animeChunks.push(
+      createContextChunk({
+        id: "runtime-anime:top-genres",
+        type: "anime",
+        title: "Anime Genres",
+        content: `Boston's top anime genres (based on watch count and rating): ${anilistData.topGenres
+          .map((g) => `${g.name} (${g.count} titles, avg score: ${g.score})`)
+          .join(", ")}.`,
+        section: "anime",
+      }),
+    );
+  }
+
+  if (anilistData.topTags.length) {
+    animeChunks.push(
+      createContextChunk({
+        id: "runtime-anime:top-tags",
+        type: "anime",
+        title: "Anime Themes/Tags",
+        content: `Themes and tags Boston frequently enjoys: ${anilistData.topTags
+          .map((t) => t.name)
+          .join(", ")}.`,
+        section: "anime",
+      }),
+    );
+  }
+
+  if (anilistData.watching && anilistData.watching.length) {
+    animeChunks.push(
+      createContextChunk({
+        id: "runtime-anime:watching",
+        type: "anime",
+        title: "Currently Watching",
+        content: `Boston is currently watching: ${anilistData.watching
+          .map((w) => `${w.title}${w.score ? ` (rated ${w.score})` : ""}`)
+          .join(", ")}.`,
+        section: "anime",
+      }),
+    );
+  }
+
+  anilistContextCache = {
+    expiresAt: Date.now() + ANILIST_CONTEXT_TTL_MS,
+    chunks: animeChunks,
+  };
+
+  return animeChunks;
+}
+
+const DYNAMIC_CONTEXT_SOURCES: DynamicContextSource[] = [
+  {
+    name: "github",
+    shouldInclude: shouldFetchGithubContext,
+    loader: getGithubRuntimeContext,
+  },
+  {
+    name: "lastfm",
+    shouldInclude: shouldFetchMusicContext,
+    loader: getLastfmRuntimeContext,
+  },
+  {
+    name: "anilist",
+    loader: getAnilistRuntimeContext,
+  },
+];
+
 async function getDynamicContext(message: string) {
   const dynamicChunks: ContextChunk[] = [];
 
-  if (shouldFetchGithubContext(message)) {
-    try {
-      dynamicChunks.push(...(await getGithubRuntimeContext()));
-    } catch (error) {
-      console.error("GitHub dynamic context failed", error);
+  for (const source of DYNAMIC_CONTEXT_SOURCES) {
+    if (source.shouldInclude && !source.shouldInclude(message)) {
+      console.info(`[dynamic-context] skipping ${source.name} (trigger mismatch)`);
+      continue;
     }
-  }
 
-  if (shouldFetchMusicContext(message)) {
+    console.info(`[dynamic-context] executing loader ${source.name}`);
+
     try {
-      dynamicChunks.push(...(await getLastfmRuntimeContext()));
+      dynamicChunks.push(...(await source.loader()));
     } catch (error) {
-      console.error("Last.fm dynamic context failed", error);
+      console.error(source.name + " dynamic context failed", error);
     }
   }
 
   return dynamicChunks;
 }
-
 function scoreChunk(messageTokens: string[], chunk: ContextChunk) {
   const haystack = normalizeText(
-    [chunk.type, chunk.title, chunk.content, chunk.section, ...(chunk.keywords || [])]
+    [
+      chunk.type,
+      chunk.title,
+      chunk.content,
+      chunk.section,
+      ...(chunk.keywords || []),
+    ]
       .filter(Boolean)
       .join(" "),
   );
@@ -313,30 +516,74 @@ function scoreChunk(messageTokens: string[], chunk: ContextChunk) {
 
   let score = 0;
   for (const token of messageTokens) {
-    if (haystack.includes(` ${token} `) || haystack.startsWith(`${token} `) || haystack.endsWith(` ${token}`)) {
+    if (
+      haystack.includes(` ${token} `) ||
+      haystack.startsWith(`${token} `) ||
+      haystack.endsWith(` ${token}`)
+    ) {
       score += 3;
     } else if (haystack.includes(token)) {
       score += 1;
     }
   }
 
-  if (chunk.type === "project" && messageTokens.some((token) => ["project", "projects", "build", "built", "repo"].includes(token))) {
+  if (
+    chunk.type === "project" &&
+    messageTokens.some((token) =>
+      ["project", "projects", "build", "built", "repo"].includes(token),
+    )
+  ) {
     score += 2;
   }
 
-  if (chunk.type === "experience" && messageTokens.some((token) => ["work", "worked", "experience", "job", "jobs"].includes(token))) {
+  if (
+    chunk.type === "experience" &&
+    messageTokens.some((token) =>
+      ["work", "worked", "experience", "job", "jobs"].includes(token),
+    )
+  ) {
     score += 2;
   }
 
-  if (chunk.type === "blog" && messageTokens.some((token) => ["blog", "post", "writing"].includes(token))) {
+  if (
+    chunk.type === "blog" &&
+    messageTokens.some((token) => ["blog", "post", "writing"].includes(token))
+  ) {
     score += 2;
   }
 
-  if (chunk.type === "music" && messageTokens.some((token) => ["music", "song", "songs", "album", "albums", "artist", "artists", "listen", "listening"].includes(token))) {
+  if (
+    chunk.type === "music" &&
+    messageTokens.some((token) =>
+      [
+        "music",
+        "song",
+        "songs",
+        "album",
+        "albums",
+        "artist",
+        "artists",
+        "listen",
+        "listening",
+      ].includes(token),
+    )
+  ) {
     score += 2;
   }
 
-  if (chunk.type === "contact" && messageTokens.some((token) => ["contact", "reach", "email", "linkedin"].includes(token))) {
+  if (
+    chunk.type === "contact" &&
+    messageTokens.some((token) =>
+      ["contact", "reach", "email", "linkedin"].includes(token),
+    )
+  ) {
+    score += 2;
+  }
+
+  if (
+    chunk.type === "anime" &&
+    messageTokens.some((token) => ANIME_QUERY_TERMS.includes(token))
+  ) {
     score += 2;
   }
 
@@ -348,7 +595,9 @@ async function loadContext() {
   const parsed = bundledContext;
 
   if (!Array.isArray(parsed)) {
-    const error = new Error("Invalid ai-context.json format: expected an array.");
+    const error = new Error(
+      "Invalid ai-context.json format: expected an array.",
+    );
     Sentry.captureException(error, {
       tags: { section: "context-loading" },
     });
@@ -360,7 +609,13 @@ async function loadContext() {
 }
 
 function retrieveTopContext(message: string, context: ContextChunk[]) {
-  const tokens = [...new Set(normalizeText(message).split(" ").filter((token) => token.length > 2))];
+  const tokens = [
+    ...new Set(
+      normalizeText(message)
+        .split(" ")
+        .filter((token) => token.length > 2),
+    ),
+  ];
 
   const ranked = context
     .map((chunk) => ({ chunk, score: scoreChunk(tokens, chunk) }))
@@ -392,11 +647,16 @@ function parseJsonObject(raw: string) {
   }
 }
 
-function isValidActionTarget(action: Exclude<ChatAction, "none">, target: string) {
+function isValidActionTarget(
+  action: Exclude<ChatAction, "none">,
+  target: string,
+) {
   return ACTION_TARGETS[action].includes(target);
 }
 
-function validateAssistantPayload(payload: unknown): ChatResponsePayload | null {
+function validateAssistantPayload(
+  payload: unknown,
+): ChatResponsePayload | null {
   if (!payload || typeof payload !== "object") return null;
 
   const candidate = payload as Record<string, unknown>;
@@ -421,14 +681,19 @@ function validateAssistantPayload(payload: unknown): ChatResponsePayload | null 
   };
 
   if (action !== "none") {
-    if (typeof candidate.target !== "string" || !isValidActionTarget(action, candidate.target)) {
+    if (
+      typeof candidate.target !== "string" ||
+      !isValidActionTarget(action, candidate.target)
+    ) {
       return null;
     }
     cleaned.target = candidate.target;
   }
 
   if (Array.isArray(candidate.suggestions)) {
-    cleaned.suggestions = candidate.suggestions.filter((item): item is string => typeof item === "string").slice(0, 5);
+    cleaned.suggestions = candidate.suggestions
+      .filter((item): item is string => typeof item === "string")
+      .slice(0, 5);
   }
 
   if (!cleaned.suggestions || cleaned.suggestions.length === 0) {
@@ -447,7 +712,15 @@ function fallbackResponse(): ChatResponsePayload {
   };
 }
 
-async function callModel({ message, history, context }: { message: string; history: ChatMessage[]; context: ContextChunk[] }) {
+async function callModel({
+  message,
+  history,
+  context,
+}: {
+  message: string;
+  history: ChatMessage[];
+  context: ContextChunk[];
+}) {
   const gatewayKey = import.meta.env.AI_GATEWAY_API_KEY;
   const model = import.meta.env.AI_MODEL || "openai/gpt-4.1-mini";
 
@@ -459,7 +732,9 @@ async function callModel({ message, history, context }: { message: string; histo
 
   const contextBlock = context
     .map((chunk) => {
-      const heading = [chunk.type.toUpperCase(), chunk.title].filter(Boolean).join(" - ");
+      const heading = [chunk.type.toUpperCase(), chunk.title]
+        .filter(Boolean)
+        .join(" - ");
       const source = chunk.url ? `Source: ${chunk.url}` : "";
       return `${heading}\n${source}\n${chunk.content}`.trim();
     })
@@ -469,7 +744,7 @@ async function callModel({ message, history, context }: { message: string; histo
     "You are Boston Rohan's portfolio assistant.",
     "Only answer with facts supported by provided context.",
     "If any information in the context (such as song or album titles) contains explicit language or profanity, you MUST censor it in your response using asterisks (e.g., 'F***'). NEVER output profanity in full.",
-    "If the answer is not in context, say so briefly and suggest relevant sections.",
+    "If the answer isn’t clearly in context, explain what you do know from the provided facts and suggest relevant sections when helpful.",
     "Avoid explicit language and profanity in your responses.",
     "Return JSON only with this shape:",
     '{"message":"string","action":"scroll|navigate|highlight|none","target":"projects|experience|blog|contact|home(optional when action=none)","suggestions":["projects","experience","music","blog","contact"]}',
@@ -485,25 +760,30 @@ async function callModel({ message, history, context }: { message: string; histo
     .map((item) => `${item.role}: ${item.content}`)
     .join("\n")}\nuser: ${message}`;
 
-  const response = await fetch("https://ai-gateway.vercel.sh/v1/chat/completions", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${gatewayKey}`,
+  const response = await fetch(
+    "https://ai-gateway.vercel.sh/v1/chat/completions",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${gatewayKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        temperature: 0.2,
+        messages: [
+          { role: "system", content: systemPrompt },
+          { role: "user", content: userPrompt },
+        ],
+      }),
     },
-    body: JSON.stringify({
-      model,
-      temperature: 0.2,
-      messages: [
-        { role: "system", content: systemPrompt },
-        { role: "user", content: userPrompt },
-      ],
-    }),
-  });
+  );
 
   if (!response.ok) {
     const details = await response.text();
-    const error = new Error(`Gateway request failed (${response.status}): ${details}`);
+    const error = new Error(
+      `Gateway request failed (${response.status}): ${details}`,
+    );
     Sentry.captureException(error, {
       tags: { service: "ai-gateway" },
       extra: { status: response.status },
@@ -532,7 +812,8 @@ export const POST: APIRoute = async ({ request, url }) => {
     }
 
     const body = await request.json();
-    const message = typeof body?.message === "string" ? body.message.trim() : "";
+    const message =
+      typeof body?.message === "string" ? body.message.trim() : "";
     const history = Array.isArray(body?.history)
       ? body.history
           .filter(
@@ -554,7 +835,10 @@ export const POST: APIRoute = async ({ request, url }) => {
 
     const context = await loadContext();
     const dynamicContext = await getDynamicContext(message);
-    const topContext = retrieveTopContext(message, [...dynamicContext, ...context]);
+    const topContext = retrieveTopContext(message, [
+      ...dynamicContext,
+      ...context,
+    ]);
 
     const rawModelOutput = await callModel({
       message,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -269,3 +269,31 @@
   text-decoration: underline;
   text-underline-offset: 0.15em;
 }
+
+@keyframes ai-thinking-bounce {
+  0%, 80%, 100% {
+    transform: translateY(0);
+    opacity: 0.2;
+  }
+  40% {
+    transform: translateY(-3px);
+    opacity: 1;
+  }
+}
+
+.ai-thinking-dots {
+  display: inline-flex;
+  gap: 0.1rem;
+}
+
+.ai-thinking-dots span {
+  animation: ai-thinking-bounce 0.9s ease-in-out infinite;
+}
+
+.ai-thinking-dots span:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.ai-thinking-dots span:nth-child(3) {
+  animation-delay: 0.3s;
+}

--- a/src/utils/anilist.js
+++ b/src/utils/anilist.js
@@ -1,0 +1,285 @@
+import * as Sentry from "@sentry/astro";
+import { z } from "zod";
+
+const ANILIST_API_URL = "https://graphql.anilist.co";
+
+const AniListMediaSchema = z.object({
+  title: z.object({
+    english: z.string().nullable(),
+    romaji: z.string().nullable(),
+  }),
+  genres: z.array(z.string()),
+});
+
+const AniListUserSchema = z.object({
+  name: z.string(),
+  favourites: z
+    .object({
+      anime: z.object({
+        nodes: z.array(AniListMediaSchema),
+      }),
+    })
+    .optional(),
+  statistics: z
+    .object({
+      anime: z.object({
+        genres: z
+          .array(
+            z.object({
+              genre: z.string(),
+              count: z.number(),
+              meanScore: z.number(),
+            }),
+          )
+          .optional(),
+        tags: z
+          .array(
+            z.object({
+              tag: z.object({
+                name: z.string(),
+              }),
+              count: z.number(),
+            }),
+          )
+          .optional(),
+      }),
+    })
+    .optional(),
+});
+
+const MediaListEntrySchema = z.object({
+  status: z.string().optional(),
+  score: z.number().nullable().optional(),
+  progress: z.number().nullable().optional(),
+  progressVolumes: z.number().nullable().optional(),
+  updatedAt: z.number().optional(),
+  media: z.object({
+    title: z.object({
+      romaji: z.string().nullable().optional(),
+      english: z.string().nullable().optional(),
+      native: z.string().nullable().optional(),
+    }).optional(),
+  }).optional(),
+});
+
+const MediaListGroupSchema = z.object({
+  name: z.string().nullable().optional(),
+  status: z.string().nullable().optional(),
+  entries: z.array(MediaListEntrySchema).optional(),
+});
+
+const MediaListCollectionSchema = z.object({
+  lists: z.array(MediaListGroupSchema).optional(),
+  hasNextChunk: z.boolean().optional(),
+});
+
+const AniListResponseSchema = z.object({
+  data: z.object({
+    User: AniListUserSchema,
+    mediaListCollection: MediaListCollectionSchema.optional(),
+  }),
+});
+
+export async function fetchAnilistData(userName) {
+  const emptyData = {
+    userName: "",
+    favorites: { anime: [] },
+    topGenres: [],
+    topTags: [],
+    error: null,
+  };
+
+  if (!userName) {
+    return { ...emptyData, error: "Missing AniList username" };
+  }
+
+  const query = `
+    query ($userName: String) {
+      User(name: $userName) {
+        name
+        siteUrl
+        mediaListOptions {
+          scoreFormat
+        }
+        favourites {
+          anime(perPage: 25) {
+            nodes {
+              title {
+                romaji
+                english
+                native
+              }
+              genres
+              description(asHtml: false)
+              coverImage {
+                large
+                color
+              }
+              siteUrl
+            }
+          }
+        }
+        statistics {
+          anime {
+            count
+            meanScore
+            minutesWatched
+            genres(limit: 10, sort: COUNT_DESC) {
+              genre
+              count
+              meanScore
+            }
+            tags(limit: 10, sort: COUNT_DESC) {
+              tag {
+                name
+              }
+              count
+            }
+          }
+        }
+      }
+      mediaListCollection: MediaListCollection(
+        userName: $userName
+        type: ANIME
+        status_in: [CURRENT, REPEATING, PLANNING, COMPLETED]
+        perChunk: 200
+        sort: [UPDATED_TIME_DESC]
+      ) {
+        hasNextChunk
+        lists {
+          name
+          status
+          entries {
+            status
+            score
+            progress
+            progressVolumes
+            updatedAt
+            media {
+              title {
+                romaji
+                english
+                native
+              }
+              format
+              episodes
+              duration
+              season
+              seasonYear
+              genres
+              tags {
+                name
+              }
+              coverImage {
+                large
+                color
+              }
+              description(asHtml: false)
+              siteUrl
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  try {
+    const requestBody = JSON.stringify({ query, variables: { userName } });
+    const response = await fetch(ANILIST_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: requestBody,
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text();
+      const error = `AniList API request failed: ${response.status}`;
+      console.error(error, { status: response.status, body: responseBody, userName });
+      Sentry.captureMessage(error, {
+        level: "error",
+        tags: { service: "anilist" },
+        extra: {
+          status: response.status,
+          userName,
+          request: requestBody,
+          response: responseBody,
+        },
+      });
+      return { ...emptyData, error: `${error}: ${responseBody}` };
+    }
+
+    const responseText = await response.text();
+    const json = JSON.parse(responseText);
+
+    if (json?.errors?.length) {
+      const error = `AniList API errors: ${JSON.stringify(json.errors)}`;
+      console.error(error);
+      Sentry.captureException(new Error("AniList API GraphQLErrors"), {
+        extra: { errors: json.errors, userName },
+        tags: { service: "anilist" },
+      });
+      return { ...emptyData, error };
+    }
+
+    const parsed = AniListResponseSchema.safeParse(json);
+
+    if (!parsed.success) {
+      const error = `Invalid AniList payload: ${parsed.error.issues
+        .map((i) => i.message)
+        .join(", ")}`;
+      console.error(error, json);
+      Sentry.captureException(parsed.error, {
+        extra: { userName, json },
+        tags: { service: "anilist" },
+      });
+      return { ...emptyData, error };
+    }
+
+    const user = parsed.data.data.User;
+    const mediaListCollection = parsed.data.data.mediaListCollection;
+
+    return {
+      userName: user.name,
+      favorites: {
+        anime:
+          user.favourites?.anime.nodes.map(
+            (n) => n.title.english || n.title.romaji,
+          ) || [],
+      },
+      topGenres:
+        user.statistics?.anime.genres.map((g) => ({
+          name: g.genre,
+          count: g.count,
+          score: g.meanScore,
+        })) || [],
+      topTags:
+        user.statistics?.anime.tags.map((t) => ({
+          name: t.tag.name,
+          count: t.count,
+        })) || [],
+      watching: (mediaListCollection?.lists || [])
+        .flatMap((list) => list.entries || [])
+        .filter(
+          (entry) => entry.status === "CURRENT" || entry.status === "REPEATING",
+        )
+        .map((entry) => ({
+          title: entry.media?.title?.english || entry.media?.title?.romaji || entry.media?.title?.native || "(unknown title)",
+          score: entry.score || 0,
+        })),
+      error: null,
+    };
+  } catch (error) {
+    console.error("AniList fetch error:", error);
+    Sentry.captureException(error, {
+      extra: { userName },
+      tags: { service: "anilist" },
+    });
+    return {
+      ...emptyData,
+      error: `Failed to fetch AniList data: ${error.message}`,
+    };
+  }
+}

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -75,7 +75,7 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       user(login: $username) {
         id
         avatarUrl
-        pinnedItems(first: 6, types: REPOSITORY) {
+        pinnedItems(first: 6, types: [REPOSITORY]) {
           nodes {
             ... on Repository {
               name
@@ -115,27 +115,34 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
   `;
 
   try {
+    const requestBody = JSON.stringify({
+      query,
+      variables: { username: githubUsername },
+    });
     const response = await fetch(GITHUB_API_URL, {
       method: "POST",
       headers: {
         Authorization: `bearer ${githubAccessToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({
-        query,
-        variables: { username: githubUsername },
-      }),
+      body: requestBody,
     });
 
     if (!response.ok) {
+      const responseBody = await response.text();
       const error = `GitHub API request failed: ${response.status}`;
-      console.error(error);
+      console.error(error, { status: response.status, githubUsername, responseBody });
       Sentry.captureMessage(error, {
         level: "error",
         tags: { service: "github" },
-        extra: { status: response.status, githubUsername },
+        extra: {
+          status: response.status,
+          githubUsername,
+          request: requestBody,
+          response: responseBody,
+        },
       });
-      return { ...emptyData, error };
+      return { ...emptyData, error: `${error}: ${responseBody}` };
     }
 
     const json = await response.json();

--- a/src/utils/lastfm.js
+++ b/src/utils/lastfm.js
@@ -44,9 +44,18 @@ async function fetchLastfmMethod({ apiKey, username, method, limit = 5, period }
     searchParams.set("period", period);
   }
 
-  const response = await fetch(`${LASTFM_API_BASE}?${searchParams.toString()}`);
+  const url = `${LASTFM_API_BASE}?${searchParams.toString()}`;
+  const response = await fetch(url);
   if (!response.ok) {
-    throw new Error(`Last.fm request failed (${response.status}) for ${method}`);
+    const body = await response.text();
+    const error = `Last.fm request failed (${response.status}) for ${method}`;
+    console.error(error, { method, status: response.status, url, body });
+    Sentry.captureMessage(error, {
+      level: "error",
+      tags: { service: "lastfm" },
+      extra: { method, status: response.status, url, body },
+    });
+    throw new Error(`${error}: ${body}`);
   }
 
   return response.json();


### PR DESCRIPTION
## Summary
- keep the assistant terminal-style log pinned to the bottom of the chat with animated thinking dots and refreshed prompts
- capture AniList/GitHub/Last.fm context, cache behavior, and any fetch errors so we know exactly what data the model sees
- add repo instructions + context query updates so AniList favorites, stats, and lists feed the assistant

## Testing
- Not run (not requested)
