### PR TITLE
Add GitHub metadata logging for pinned repo fetch

### DIFF
--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -93,7 +93,7 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       user(login: $username) {
         id
         avatarUrl
-        pinnedItems(first: 6) {
+        pinnedItems(first: 6, types: [REPOSITORY]) {
           nodes {
             __typename
             ... on Repository {

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -55,6 +55,24 @@ const GitHubResponseSchema = z.object({
   }),
 });
 
+function getGitHubResponseMetadata(response) {
+  const headers = response.headers;
+  const readHeader = (name) => headers.get(name) ?? undefined;
+  let host;
+  try {
+    host = new URL(response.url).host;
+  } catch (error) {
+    host = undefined;
+  }
+  return {
+    url: response.url,
+    host,
+    enterpriseVersion: readHeader("x-github-enterprise-version"),
+    mediaType: readHeader("x-github-media-type"),
+    requestId: readHeader("x-github-request-id"),
+  };
+}
+
 export async function fetchPinnedGithubData({ githubUsername, githubAccessToken }) {
   const emptyData = {
     githubUserId: "",
@@ -75,8 +93,9 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       user(login: $username) {
         id
         avatarUrl
-        pinnedItems(first: 6, types: [REPOSITORY]) {
+        pinnedItems(first: 6) {
           nodes {
+            __typename
             ... on Repository {
               name
               url
@@ -127,11 +146,12 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       },
       body: requestBody,
     });
+    const responseMetadata = getGitHubResponseMetadata(response);
 
     if (!response.ok) {
       const responseBody = await response.text();
       const error = `GitHub API request failed: ${response.status}`;
-      console.error(error, { status: response.status, githubUsername, responseBody });
+      console.error(error, { status: response.status, githubUsername, responseBody }, responseMetadata);
       Sentry.captureMessage(error, {
         level: "error",
         tags: { service: "github" },
@@ -140,6 +160,7 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
           githubUsername,
           request: requestBody,
           response: responseBody,
+          githubMetadata: responseMetadata,
         },
       });
       return { ...emptyData, error: `${error}: ${responseBody}` };
@@ -149,9 +170,9 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
 
     if (json?.errors?.length) {
       const error = `GitHub API errors: ${JSON.stringify(json.errors)}`;
-      console.error(error);
+      console.error(error, responseMetadata);
       Sentry.captureException(new Error("GitHub API GraphQLErrors"), {
-        extra: { errors: json.errors, githubUsername },
+        extra: { errors: json.errors, githubUsername, githubMetadata: responseMetadata },
         tags: { service: "github" },
       });
       return {
@@ -160,7 +181,31 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       };
     }
 
-    const parsedProjects = GitHubResponseSchema.safeParse(json);
+    const normalizedResponse = (() => {
+      const nodes = json?.data?.user?.pinnedItems?.nodes;
+      if (!Array.isArray(nodes)) {
+        return json;
+      }
+      const repositoryNodes = nodes.filter((node) => node?.__typename === "Repository");
+      if (repositoryNodes.length === nodes.length) {
+        return json;
+      }
+      return {
+        ...json,
+        data: {
+          ...json.data,
+          user: {
+            ...json.data.user,
+            pinnedItems: {
+              ...json.data.user.pinnedItems,
+              nodes: repositoryNodes,
+            },
+          },
+        },
+      };
+    })();
+
+    const parsedProjects = GitHubResponseSchema.safeParse(normalizedResponse);
 
     if (!parsedProjects.success) {
       const error = `Invalid GitHub project payload: ${parsedProjects.error.issues
@@ -168,7 +213,7 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
         .join(", ")}`;
       console.error(error, json);
       Sentry.captureException(parsedProjects.error, {
-        extra: { githubUsername, json },
+        extra: { githubUsername, json, githubMetadata: responseMetadata },
         tags: { service: "github" },
       });
       return {

--- a/src/utils/github.js
+++ b/src/utils/github.js
@@ -181,31 +181,7 @@ export async function fetchPinnedGithubData({ githubUsername, githubAccessToken 
       };
     }
 
-    const normalizedResponse = (() => {
-      const nodes = json?.data?.user?.pinnedItems?.nodes;
-      if (!Array.isArray(nodes)) {
-        return json;
-      }
-      const repositoryNodes = nodes.filter((node) => node?.__typename === "Repository");
-      if (repositoryNodes.length === nodes.length) {
-        return json;
-      }
-      return {
-        ...json,
-        data: {
-          ...json.data,
-          user: {
-            ...json.data.user,
-            pinnedItems: {
-              ...json.data.user.pinnedItems,
-              nodes: repositoryNodes,
-            },
-          },
-        },
-      };
-    })();
-
-    const parsedProjects = GitHubResponseSchema.safeParse(normalizedResponse);
+    const parsedProjects = GitHubResponseSchema.safeParse(json);
 
     if (!parsedProjects.success) {
       const error = `Invalid GitHub project payload: ${parsedProjects.error.issues


### PR DESCRIPTION
    - capture the resolved GraphQL endpoint plus key GitHub headers (host, enterprise
  version, media type, request ID) for every fetch
    - include that metadata in console logs and Sentry extras whenever the GitHub request
  fails, returns GraphQL errors, or Zod rejects the payload
    - continue filtering pinned nodes by `__typename === "Repository"` before validating so
  the schema error doesn’t recur